### PR TITLE
Fix: [Vue warn]Failed setting prop "content" on template

### DIFF
--- a/src/components/HIconButton.vue
+++ b/src/components/HIconButton.vue
@@ -43,8 +43,8 @@ const toggle = () => {
 </script>
 
 <template>
-  <component :content="label" :is="noTooltip ? 'template' : HTooltip">
-    <component :is="as || 'button'" :aria-label="label" :disabled="disabled" class="h-icon-button" :class="{      
+  <component :content="label" :is="noTooltip ? 'div' : HTooltip">
+    <component :is="as || 'button'" :aria-label="label" :disabled="disabled" class="h-icon-button" :class="{
       selected,
       toggleable: _toggleable,
       [kind || 'standard']: true,


### PR DESCRIPTION
The following warn occured when using a `HIconButton` and set `label="label" :noTooltip="true"`:
`[Vue warn]Failed setting prop "content" on <template>: value label is invalid. TypeError: Cannot set property content of #<HTMLTemplateElement> which has only a getter`

It's because `HTMLTemplateElement` dynamically create(not rendered as a vue `template` placeholder) when noTooltip applies, but the element can not apply custom properties.