### PR TITLE
fix: document undefined in SSR env

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -7,7 +7,7 @@ export const isLink = /* @__PURE__ */ (component: string | Component) => {
     const name = typeof component === 'string' ? component : component.name
 
     return LINK_COMPONENTS.includes(name)
-} 
+}
 
 interface HideOnScrollOptions {
     onUp: () => any
@@ -16,12 +16,12 @@ interface HideOnScrollOptions {
 
 export const useHideOnScroll = /* @__PURE__ */ ({ onUp, onDown }: HideOnScrollOptions) => {
     const scroll = useScroll(
-        document,
+        typeof document !== 'undefined' ? document : undefined, // ssr compatible
         { throttle: 300, eventListenerOptions: true }
     )
 
     const { top: up, bottom: down } = toRefs(scroll.directions)
-    
+
     watch([up, down], ([up, down]) => {
         if (up) onUp()
         if (down) onDown()

--- a/src/components/HNavigationDrawer.vue
+++ b/src/components/HNavigationDrawer.vue
@@ -38,7 +38,9 @@ provide('in drawer', true);
 </script>
 
 <template>
-    <div class="drawer-swiping-mask" ref="mask"/>
+    <Teleport to="body">
+      <div class="drawer-swiping-mask" ref="mask"/>
+    </Teleport>
     <Teleport to="body" v-if="static">
         <nav><slot /></nav>
     </Teleport>

--- a/src/components/HNavigationDrawer.vue
+++ b/src/components/HNavigationDrawer.vue
@@ -7,7 +7,7 @@ import {
     DialogTitle
 } from '@headlessui/vue'
 import { useSwipe } from '@vueuse/core';
-import { provide, watch } from 'vue';
+import {provide, ref, watch} from 'vue';
 
 const props = defineProps<{
     title?: string
@@ -17,9 +17,11 @@ const props = defineProps<{
 
 const emit = defineEmits<{ (e: 'update:open', modelValue: boolean): any; }>()
 
+const mask = ref<HTMLDivElement>()
+
 const close = () => emit('update:open', false)
 
-const { isSwiping, direction } = useSwipe(document)
+const { isSwiping, direction } = useSwipe(mask)
 
 watch(isSwiping, (isSwiping) => {
     if (props.static) return
@@ -36,6 +38,7 @@ provide('in drawer', true);
 </script>
 
 <template>
+    <div class="drawer-swiping-mask" ref="mask"/>
     <Teleport to="body" v-if="static">
         <nav><slot /></nav>
     </Teleport>
@@ -125,5 +128,10 @@ nav {
 
 .scrim-to {
     opacity: 1;
+}
+
+.drawer-swiping-mask{
+    position: fixed;
+    inset: 0;
 }
 </style>


### PR DESCRIPTION
`document` element is undefined in a SSR env, which will cause error occurs, the fix create a full-screen mask element to replace the origin `document` element to fix the issue in `h-navigation-drawer` component