### PR TITLE
fix: [vite:css] start value has mixed support

### DIFF
--- a/src/components/HNavigationRail.vue
+++ b/src/components/HNavigationRail.vue
@@ -86,7 +86,7 @@ section {
     flex: 1;
 
     &.top {
-        justify-content: start;
+        justify-content: flex-start;
     }
 
     &.center {

--- a/src/components/HSnackbar.vue
+++ b/src/components/HSnackbar.vue
@@ -94,7 +94,7 @@ const stateClasses = {
     justify-content: center;
 
     &.left {
-        justify-content: start;
+        justify-content: flex-start;
     }
 
     &.bottom-bar-open, &.nav-bar-open {

--- a/src/components/HTopAppBar.vue
+++ b/src/components/HTopAppBar.vue
@@ -55,7 +55,7 @@ const _kind = computed(() => {
         <div class="trailing">
             <slot name="trailing" />
         </div>
-        
+
     </header>
 </template>
 
@@ -155,7 +155,7 @@ header {
 .leading {
     display: flex;
     flex-direction: row;
-    justify-content: start;
+    justify-content: flex-start;
     margin-left: 8px;
 }
 


### PR DESCRIPTION
This pr fix a warn:`[vite:css] start value has mixed support, consider using flex-start instead`